### PR TITLE
connected but off screens cause breakage

### DIFF
--- a/window_grid
+++ b/window_grid
@@ -131,7 +131,7 @@ declare -a SCREEN_DIMENSIONS
 function get_screen_dimensions() 
 {
     i=0
-    LINES=$(xrandr |grep ' connected' |cut -d\( -f 1 |awk '{print $NF}')
+    LINES=$(xrandr |grep ' connected' | grep '[0-9]x[0-9]' |cut -d\( -f 1 |awk '{print $NF}')
     while IFS= read -r line; do
         IFS=: read width height startx starty <<< "${line//[+x]/:}"
         endx=$(( $width + $startx ))


### PR DESCRIPTION
I often have my laptop connected to my main large screen, however I usually prefer the laptop screen to be off.

If this is the case the window ends up super tiny (probably 0x0).

I have added a tiny bit of `grep` to stop the connected-but-off screens appearing.